### PR TITLE
Specify manifest is obj in server spec

### DIFF
--- a/inst/demo-server-spec.R
+++ b/inst/demo-server-spec.R
@@ -1,6 +1,6 @@
 source("./demo-user-script.R")
 
-#* @post /eval
+#* @post /eval:object
 function(manifest) {
    bussin:::process_request(manifest)
 }


### PR DESCRIPTION
https://www.rplumber.io/articles/annotations.html. Basically need to specify manifest is an object so it can be in the body of a request instead of being a part of the query/path